### PR TITLE
making sure that the adjust function respects any rounding needs.

### DIFF
--- a/Modules/AdjustDKP.lua
+++ b/Modules/AdjustDKP.lua
@@ -10,6 +10,7 @@ function MonDKP:AdjustDKP(value)
 	local curTime = time()
 	local c;
 	local curOfficer = UnitName("player")
+	value = MonDKP_round(value, core.DB.modes.rounding);
 
 	if not IsInRaid() then
 		c = MonDKP:GetCColors();


### PR DESCRIPTION
Fixing the lack of rounding in DKP History by making sure the value in the Adjust Bid is respectful of the rounding needs.  This accounts for bug #5 