### PR TITLE
Making sure that every function is either local or in the CommDKP-…

### DIFF
--- a/CommunityDKP.lua
+++ b/CommunityDKP.lua
@@ -71,7 +71,7 @@ function CommDKP:Toggle()        -- toggles IsShown() state of CommDKP.UIConfig,
 	end
 
 	CommDKP:StatusVerify_Update()
-	DKPTable_Update()
+	CommDKP:DKPTable_Update()
 end
 
 ---------------------------------------
@@ -170,7 +170,7 @@ function CommDKP:SortDKPTable(id, reset)        -- reorganizes core.WorkingTable
 	if id == "class" or id == "rank" or id == "role" or id == "spec" then
 		button = SortButtons.class
 	elseif id == "spec" then                -- doesn't allow "spec" to be sorted.
-		DKPTable_Update()
+		CommDKP:DKPTable_Update()
 		return;
 	else
 		button = SortButtons[id]
@@ -218,7 +218,7 @@ function CommDKP:SortDKPTable(id, reset)        -- reorganizes core.WorkingTable
 		end
 	end)
 	core.currentSort = id;
-	DKPTable_Update()
+	CommDKP:DKPTable_Update()
 end
 
 function CommDKP:CreateMenu()
@@ -660,7 +660,7 @@ function CommDKP:CreateMenu()
 	CommDKP.UIConfig.Version:SetText(core.MonVersion); 
 
 	CommDKP.UIConfig:Hide(); -- hide menu after creation until called.
-	CommDKP:FilterDKPTable(core.currentSort)   -- initial sort and populates data values in DKPTable.Rows{} CommDKP:FilterDKPTable() -> CommDKP:SortDKPTable() -> DKPTable_Update()
+	CommDKP:FilterDKPTable(core.currentSort)   -- initial sort and populates data values in DKPTable.Rows{} CommDKP:FilterDKPTable() -> CommDKP:SortDKPTable() -> CommDKP:DKPTable_Update()
 	core.Initialized = true
 	return CommDKP.UIConfig;
 end

--- a/ConfigMenuTabs.lua
+++ b/ConfigMenuTabs.lua
@@ -309,6 +309,5 @@ function CommDKP:ConfigMenuTabs()
 	if #CommDKP:GetTable(CommDKP_DKPHistory, true) > 0 then
 		CommDKP:DKPHistory_Update()
 	end
-	DKPHistoryFilterBox_Create()
+	CommDKP:DKPHistoryFilterBox_Create()
 end
-	

--- a/Core.lua
+++ b/Core.lua
@@ -604,6 +604,13 @@ end
 -------
 -- TEAM FUNCTIONS
 -------
+local function tablelength(T)
+	local count = 0
+	for _ in pairs(T) do
+		count = count + 1 
+	end
+	return count
+end
 
 function CommDKP:GetCurrentTeamIndex() 
 	local _tmpString = CommDKP:GetTable(CommDKP_DB, false)["defaults"]["CurrentTeam"] or "0"
@@ -629,15 +636,6 @@ function CommDKP:GetTeamName(index)
 	if teamName == nil then return "no team" end;
 
 	return teamName;
-end
-
-
-function tablelength(T)
-	local count = 0
-	for _ in pairs(T) do
-		count = count + 1 
-	end
-	return count
 end
 
 function CommDKP:GetGuildTeamList() 
@@ -673,7 +671,7 @@ function CommDKP:SetCurrentTeam(index)
 	-- reset dkp table and update it
 	core.WorkingTable = CommDKP:GetTable(CommDKP_DKPTable, true);
 	core.PriceTable	= CommDKP:GetTable(CommDKP_MinBids, true);
-	DKPTable_Update()
+	CommDKP:DKPTable_Update()
 
 	-- reset dkp history table and update it
 	CommDKP:DKPHistory_Update(true)
@@ -839,5 +837,5 @@ function CommDKP:DKPTable_Set(tar, field, value, loot)                -- updates
 			CommDKP:GetTable(CommDKP_DKPTable, true)[result[i][1]][field] = value
 		end
 	end
-	DKPTable_Update()
+	CommDKP:DKPTable_Update()
 end

--- a/Modules/AdjustDKP.lua
+++ b/Modules/AdjustDKP.lua
@@ -49,7 +49,7 @@ function CommDKP:AdjustDKP(value)
 			if CommDKP.ConfigTab6.history and CommDKP.ConfigTab6:IsShown() then
 				CommDKP:DKPHistory_Update(true)
 			end
-			DKPTable_Update()
+			CommDKP:DKPTable_Update()
 			if IsInRaid() then
 				CommDKP.Sync:SendData("CommDKPBCastMsg", L["RAIDDKPADJUSTBY"].." "..value.." "..L["FORREASON"]..": "..adjustReason)
 			else
@@ -130,7 +130,7 @@ local function DecayDKP(amount, deductionType, GetSelections)
 	if CommDKP.ConfigTab6.history then
 		CommDKP:DKPHistory_Update(true)
 	end
-	DKPTable_Update()
+	CommDKP:DKPTable_Update()
 end
 
 local function RaidTimerPopout_Create()

--- a/Modules/AutoAward.lua
+++ b/Modules/AutoAward.lua
@@ -66,7 +66,7 @@ function CommDKP:AutoAward(phase, amount, reason) -- phase identifies who to awa
 			if CommDKP.ConfigTab6.history and CommDKP.ConfigTab6:IsShown() then
 				CommDKP:DKPHistory_Update(true)
 			end
-			DKPTable_Update()
+			CommDKP:DKPTable_Update()
 		end
 	end
 end

--- a/Modules/BidInterface.lua
+++ b/Modules/BidInterface.lua
@@ -131,7 +131,7 @@ local function UpdateBidderWindow()
 	core.BidInterface.Boss:SetText(core.DB.bossargs.LastKilledBoss)
 end
 
-function BidInterface_Update()
+local function BidInterface_Update()
   local numOptions = #Bids_Submitted;
   local index, row
     local offset = FauxScrollFrame_GetOffset(core.BidInterface.bidTable) or 0

--- a/Modules/BidInterface.lua
+++ b/Modules/BidInterface.lua
@@ -131,7 +131,7 @@ local function UpdateBidderWindow()
 	core.BidInterface.Boss:SetText(core.DB.bossargs.LastKilledBoss)
 end
 
-function BidInterface_Update()
+function CommDKP_BidInterface_Update()
   local numOptions = #Bids_Submitted;
   local index, row
     local offset = FauxScrollFrame_GetOffset(core.BidInterface.bidTable) or 0
@@ -282,7 +282,7 @@ function CommDKP:BidInterface_Toggle()
   end
 
   if core.DB.modes.BroadcastBids then
-    local pass, err = pcall(BidInterface_Update)
+    local pass, err = pcall(CommDKP_BidInterface_Update)
 
     if not pass then
       print(err)
@@ -424,7 +424,7 @@ end
 function CommDKP:Bids_Set(entry)
   Bids_Submitted = entry;
   
-  local pass, err = pcall(BidInterface_Update)
+  local pass, err = pcall(CommDKP_BidInterface_Update)
 
   if not pass then
     print(err)

--- a/Modules/BidInterface.lua
+++ b/Modules/BidInterface.lua
@@ -131,7 +131,7 @@ local function UpdateBidderWindow()
 	core.BidInterface.Boss:SetText(core.DB.bossargs.LastKilledBoss)
 end
 
-local function BidInterface_Update()
+function BidInterface_Update()
   local numOptions = #Bids_Submitted;
   local index, row
     local offset = FauxScrollFrame_GetOffset(core.BidInterface.bidTable) or 0

--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -1601,7 +1601,7 @@ function CommDKP:CreateBidWindow()
           end
       end
       f.bidTable:SetScript("OnVerticalScroll", function(self, offset)
-          FauxScrollFrame_OnVerticalScroll(self, offset, height, CommDKP:BidScrollFrame_Update())
+          FauxScrollFrame_OnVerticalScroll(self, offset, height, CommDKP.BidScrollFrame_Update)
       end)
 
     ---------------------------------------

--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -93,7 +93,7 @@ local function Roll_OnEvent(self, event, arg1, ...)
           SendChatMessage(L["ONLYONEROLLWARN"], "WHISPER", nil, name)
         end
       end
-      BidScrollFrame_Update()
+      CommDKP:BidScrollFrame_Update()
     end
   end
 end
@@ -138,7 +138,7 @@ function CommDKP_CHAT_MSG_WHISPER(text, ...)
             if core.DB.modes.BroadcastBids then
               CommDKP.Sync:SendData("CommDKPBidShare", Bids_Submitted)
             end
-            BidScrollFrame_Update()
+            CommDKP:BidScrollFrame_Update()
             response = L["BIDCANCELLED"]
             flagCanceled = true
             --SendChatMessage(response, "WHISPER", nil, name)
@@ -213,7 +213,7 @@ function CommDKP_CHAT_MSG_WHISPER(text, ...)
                   CommDKP:BroadcastBidTimer(seconds, core.BiddingWindow.item:GetText().." Extended", core.BiddingWindow.itemIcon:GetTexture());
                 end
               end
-              BidScrollFrame_Update()
+              CommDKP:BidScrollFrame_Update()
             else
               response = L["BIDDENIEDMINBID"].." "..core.BiddingWindow.minBid:GetNumber().."!"
             end
@@ -535,7 +535,7 @@ function CommDKP:ToggleBidWindow(loot, lootIcon, itemName)
        UpdateBidWindow()
      end
 
-     BidScrollFrame_Update()
+     CommDKP:BidScrollFrame_Update()
   else
     CommDKP:Print(L["NOPERMISSION"])
   end
@@ -687,7 +687,7 @@ function ClearBidWindow()
   core.BiddingWindow.CustomMinBid:Hide();
 
   core.BiddingWindow.ItemTooltipButton:SetSize(0,0)
-  BidScrollFrame_Update()
+  CommDKP:BidScrollFrame_Update()
   UpdateBidWindow()
   core.BidInProgress = false;
   core.BiddingWindow.boss:SetText("")
@@ -1092,7 +1092,7 @@ local function RightClickMenu(self)
         core.BiddingWindow.bidTable.Rows[i]:SetNormalTexture("Interface\\COMMON\\talent-blue-glow")
         core.BiddingWindow.bidTable.Rows[i]:GetNormalTexture():SetAlpha(0.2)
       end
-      BidScrollFrame_Update()
+      CommDKP:BidScrollFrame_Update()
     end },
   }
   EasyMenu(menu, menuFrame, "cursor", 0 , 0, "MENU", 1);
@@ -1149,7 +1149,7 @@ local function SortBidTable()             -- sorts the Loot History Table by dat
     end)
 end
 
-function BidScrollFrame_Update()
+function CommDKP:BidScrollFrame_Update()
   local numOptions = #Bids_Submitted;
   local index, row
     local offset = FauxScrollFrame_GetOffset(core.BiddingWindow.bidTable) or 0
@@ -1601,7 +1601,7 @@ function CommDKP:CreateBidWindow()
           end
       end
       f.bidTable:SetScript("OnVerticalScroll", function(self, offset)
-          FauxScrollFrame_OnVerticalScroll(self, offset, height, BidScrollFrame_Update)
+          FauxScrollFrame_OnVerticalScroll(self, offset, height, CommDKP:BidScrollFrame_Update())
       end)
 
     ---------------------------------------

--- a/Modules/DKPHistory.lua
+++ b/Modules/DKPHistory.lua
@@ -71,7 +71,7 @@ function CommDKP:DKPHistory_Reset()
 	end
 end
 
-function DKPHistoryFilterBox_Create()
+function CommDKP:DKPHistoryFilterBox_Create()
 	local PlayerList = GetSortOptions();
 	local curSelected = 0;
 
@@ -228,7 +228,7 @@ local function CommDKPDeleteDKPEntry(index, timestamp, item)  -- index = entry i
 				end
 
 				CommDKP:StatusVerify_Update()
-				DKPTable_Update()
+				CommDKP:DKPTable_Update()
 			end
 		end,
 		timeout = 0,

--- a/Modules/LootHistory.lua
+++ b/Modules/LootHistory.lua
@@ -88,7 +88,7 @@ local function DeleteLootHistoryEntry(index)
 	table.insert(CommDKP:GetTable(CommDKP_Loot, true), 1, tempTable)
 	CommDKP.Sync:SendData("CommDKPDelLoot", tempTable)
 	CommDKP:SortLootTable()
-	DKPTable_Update()
+	CommDKP:DKPTable_Update()
 	CommDKP:LootHistory_Update(L["NOFILTER"]);
 end
 

--- a/Modules/ManageEntries.lua
+++ b/Modules/ManageEntries.lua
@@ -67,7 +67,7 @@ local function Remove_Entries()
 	end
 end
 
-function AddRaidToDKPTable()
+local function AddRaidToDKPTable()
 	local GroupType = "none";
 
 	if IsInRaid() then
@@ -241,7 +241,7 @@ local function AddTargetToDKPTable()
 	end
 end
 
-function GetGuildRankList()
+function CommDKP:GetGuildRankList()
 	local numRanks = GuildControlGetNumRanks()
 	local tempTable = {}
 	for i=1, numRanks do
@@ -553,7 +553,7 @@ function CommDKP:ManageEntries()
 					rank.func = self.SetValue
 					rank.fontObject = "CommDKPSmallCenter"
 
-					local rankList = GetGuildRankList()
+					local rankList = CommDKP:GetGuildRankList()
 
 					for i=1, #rankList do
 						rank.text, rank.arg1, rank.arg2, rank.checked, rank.isNotRadio = rankList[i].name, rankList[i].name, rankList[i].index, rankList[i].name == curRank, true

--- a/Modules/Options.lua
+++ b/Modules/Options.lua
@@ -78,7 +78,7 @@ local function SaveSettings()
   core.DB.defaults.HistoryLimit = CommDKP.ConfigTab4.history:GetNumber();
   core.DB.defaults.DKPHistoryLimit = CommDKP.ConfigTab4.DKPHistory:GetNumber();
   core.DB.defaults.TooltipHistoryCount = CommDKP.ConfigTab4.TooltipHistory:GetNumber();
-  DKPTable_Update()
+  CommDKP:DKPTable_Update()
 end
 
 function CommDKP:Options()

--- a/Modules/RaidTimer.lua
+++ b/Modules/RaidTimer.lua
@@ -12,7 +12,7 @@ local StartAwarded = false;
 local StartBonus = 0;
 local totalAwarded = 0;
 
-function SecondsToClock(seconds)
+local function SecondsToClock(seconds)
   local seconds = tonumber(seconds)
 
   if seconds <= 0 then
@@ -88,7 +88,7 @@ local function AwardRaid(amount, reason)
 		if CommDKP.ConfigTab6.history and CommDKP.ConfigTab6:IsShown() then
 			CommDKP:DKPHistory_Update(true)
 		end
-		DKPTable_Update()
+		CommDKP:DKPTable_Update()
 
 		CommDKP.Sync:SendData("CommDKPDKPDist", CommDKP:GetTable(CommDKP_DKPHistory, true)[1])
 

--- a/Modules/ZeroSumBank.lua
+++ b/Modules/ZeroSumBank.lua
@@ -58,7 +58,7 @@ local function ZeroSumDistribution()
 		table.wipe(core.DB.modes.ZeroSumBank)
 		core.DB.modes.ZeroSumBank.balance = 0
 		core.ZeroSumBank.LootFrame.LootList:SetText("")
-		DKPTable_Update()
+		CommDKP:DKPTable_Update()
 		CommDKP.Sync:SendData("CommDKPZSumBank", core.DB.modes.ZeroSumBank)
 		CommDKP:ZeroSumBank_Update()
 		core.ZeroSumBank:Hide();

--- a/Modules/comm.lua
+++ b/Modules/comm.lua
@@ -724,7 +724,7 @@ function CommDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
               if CommDKP.ConfigTab6 and CommDKP.ConfigTab6.history then
                 CommDKP:DKPHistory_Update(true)
               end
-              DKPTable_Update()
+              CommDKP:DKPTable_Update()
             elseif prefix == "CommDKPMinBid" then
               if core.IsOfficer then
                 core.DB.MinBidBySlot = _objReceived.Data[1]

--- a/TableFunctions.lua
+++ b/TableFunctions.lua
@@ -840,7 +840,7 @@ function CommDKP:DKPTable_Create()
 		end
 	end
 	CommDKP.DKPTable:SetScript("OnVerticalScroll", function(self, offset)
-		FauxScrollFrame_OnVerticalScroll(self, offset, core.TableRowHeight, CommDKP:DKPTable_Update())
+		FauxScrollFrame_OnVerticalScroll(self, offset, core.TableRowHeight, CommDKP.DKPTable_Update)
 	end)
 	
 	CommDKP.DKPTable.SeedVerify = CreateFrame("Frame", nil, CommDKP.DKPTable);

--- a/TableFunctions.lua
+++ b/TableFunctions.lua
@@ -31,7 +31,7 @@ local function CountDown(time)
 	end
 end
 
-function DKPTable_OnClick(self)   
+local function DKPTable_OnClick(self)   
 	local offset = FauxScrollFrame_GetOffset(CommDKP.DKPTable) or 0
 	local index, TempSearch;
 	SelectedRow = self.index
@@ -88,7 +88,7 @@ function DKPTable_OnClick(self)
 		end
 	end
 
-	DKPTable_Update()
+	CommDKP:DKPTable_Update()
 	CommDKPSelectionCount_Update()
 end
 
@@ -210,11 +210,11 @@ local function EditStandbyList(row, arg1)
 			end
 		end
 		CommDKP.Sync:SendData("CommDKPStand", CommDKP:GetTable(CommDKP_Standby, true))
-		DKPTable_Update()
+		CommDKP:DKPTable_Update()
 	else
 		table.wipe(CommDKP:GetTable(CommDKP_Standby, true))
 		core.WorkingTable = {}
-		DKPTable_Update()
+		CommDKP:DKPTable_Update()
 		CommDKP.Sync:SendData("CommDKPStand", CommDKP:GetTable(CommDKP_Standby, true))
 	end
 	if #core.WorkingTable == 0 then
@@ -279,7 +279,7 @@ function CommDKP:ViewLimited(raid, standby, raiders)
 				local search = CommDKP:Table_Search(CommDKP:GetTable(CommDKP_DKPTable, true), name)
 
 				if search then
-					local rankList = GetGuildRankList()
+					local rankList = CommDKP:GetGuildRankList()
 
 					local match_rank = CommDKP:Table_Search(core.DB.raiders, rankList[rankIndex+1].name)
 
@@ -301,7 +301,7 @@ function CommDKP:ViewLimited(raid, standby, raiders)
 		table.wipe(tempTable)
 
 		core.CurView = "limited"
-		DKPTable_Update()
+		CommDKP:DKPTable_Update()
 	elseif core.CurView == "limited" then
 		core.WorkingTable = CopyTable(CommDKP:GetTable(CommDKP_DKPTable, true))
 		core.CurView = "all"
@@ -335,7 +335,7 @@ local function RightClickMenu(self)
 		{ text = L["SELECTALL"], notCheckable = true, func = function()
 			core.SelectedData = CopyTable(core.WorkingTable);
 			CommDKPSelectionCount_Update()
-			DKPTable_Update()
+			CommDKP:DKPTable_Update()
 		end }, --3
 		{ text = " ", notCheckable = true, disabled = true}, --4
 		{ text = L["VIEWS"], isTitle = true, notCheckable = true}, --5
@@ -518,7 +518,7 @@ local function RightClickMenu(self)
 		menu[6].menuList[3] = { text = L["VIEWRAIDSTANDBY"], notCheckable = true, disabled = true}
 	end
 
-	local rankList = GetGuildRankList()
+	local rankList = CommDKP:GetGuildRankList()
 	for i=1, #rankList do
 		local checked;
 
@@ -561,7 +561,7 @@ local function RightClickMenu(self)
 		local search = CommDKP:Table_Search(CommDKP:GetTable(CommDKP_DKPTable, true), name)
 
 		if search then
-			local rankList = GetGuildRankList()
+			local rankList = CommDKP:GetGuildRankList()
 
 			local match_rank = CommDKP:Table_Search(core.DB.raiders, rankList[rankIndex+1].name)
 
@@ -642,7 +642,7 @@ local function CreateRow(parent, id) -- Create 3 buttons for each row in the lis
 		return f
 end
 
-function DKPTable_Update()
+function CommDKP:DKPTable_Update()
 	if not CommDKP.UIConfig:IsShown() then     -- does not update list if DKP window is closed. Gets done when /dkp is used anyway.
 		return;
 	end
@@ -840,7 +840,7 @@ function CommDKP:DKPTable_Create()
 		end
 	end
 	CommDKP.DKPTable:SetScript("OnVerticalScroll", function(self, offset)
-		FauxScrollFrame_OnVerticalScroll(self, offset, core.TableRowHeight, DKPTable_Update)
+		FauxScrollFrame_OnVerticalScroll(self, offset, core.TableRowHeight, CommDKP:DKPTable_Update())
 	end)
 	
 	CommDKP.DKPTable.SeedVerify = CreateFrame("Frame", nil, CommDKP.DKPTable);

--- a/init.lua
+++ b/init.lua
@@ -698,7 +698,7 @@ function CommDKP:UpgradeDBSchema(newDbTable, oldDbTable, hasTeams, tableName)
 	return newDbTable;
 end
 
-local function tableHasKey(table,key)
+function tableHasKey(table,key)
 	return table[key] ~= nil;
 end
 

--- a/init.lua
+++ b/init.lua
@@ -662,7 +662,7 @@ end
 function CommDKP:VerifyDBSchema(dbTable)
 	local verified = false;
 	--Check to see if the schema node exists. If not, this is 2.1.2 database.
-	local retOK, hasInfo = pcall(tableHasKey,dbTable,"dbinfo");
+	local retOK, hasInfo = pcall(CommDKP_tableHasKey,dbTable,"dbinfo");
 
 	if (not retOK) or (retOK and not hasInfo) then
 		verified = false;
@@ -675,7 +675,7 @@ end
 
 function CommDKP:UpgradeDBSchema(newDbTable, oldDbTable, hasTeams, tableName)
 	-- Initialize the Database for a Pre-2.2 Database
-	local retOK, hasInfo = pcall(tableHasKey,oldDbTable,"dbinfo");
+	local retOK, hasInfo = pcall(CommDKP_tableHasKey,oldDbTable,"dbinfo");
 	if (not retOK) or (retOK and not hasInfo) then
 		newDbTable = CommDKP:InitPlayerTable(oldDbTable, hasTeams, tableName)
 	end
@@ -698,7 +698,7 @@ function CommDKP:UpgradeDBSchema(newDbTable, oldDbTable, hasTeams, tableName)
 	return newDbTable;
 end
 
-function tableHasKey(table,key)
+function CommDKP_tableHasKey(table,key)
 	return table[key] ~= nil;
 end
 
@@ -783,14 +783,14 @@ function CommDKP:InitPlayerTable(globalTable, hasTeams, tableName)
 end
 
 function CommDKP:InitializeGuild(dataTable, realmName, guildName)
-	local retOK1, hasInfo1 = pcall(tableHasKey,dataTable,realmName);
+	local retOK1, hasInfo1 = pcall(CommDKP_tableHasKey,dataTable,realmName);
 	
 	if (not retOK1) or (retOK1 and not hasInfo1) then
 		dataTable[realmName] = {}
 	end
 	
 	if guildName ~= nil then
-		local retOK2, hasInfo2 = pcall(tableHasKey,dataTable[realmName],guildName);
+		local retOK2, hasInfo2 = pcall(CommDKP_tableHasKey,dataTable[realmName],guildName);
 		
 		if (not retOK2) or (retOK2 and not hasInfo2) then
 			dataTable[realmName][guildName] = {}

--- a/init.lua
+++ b/init.lua
@@ -202,11 +202,11 @@ function CommDKP_wait(delay, func, ...)
   return true;
 end
 
-function DoInit(event, arg1)
+local function DoInit(event, arg1)
 	CommDKP:OnInitialize(event, arg1);
 end
 
-function DoGuildUpdate()
+local function DoGuildUpdate()
 	if IsInGuild() and not core.InitStart then
 		GuildRoster()
 		core.InitStart = true
@@ -547,21 +547,21 @@ function CommDKP:OnInitialize(event, name)		-- This is the FIRST function to run
 		------------------------------------------------
 		-- Verify DB Schemas
 		------------------------------------------------
-		if not VerifyDBSchema(CommDKP_DB) then CommDKP_DB =  UpgradeDBSchema(CommDKP_DB, CommDKP_DB, false, "CommDKP_DB") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_DB) then CommDKP_DB = CommDKP:UpgradeDBSchema(CommDKP_DB, CommDKP_DB, false, "CommDKP_DB") end;
 		
 		-- Verify that the DB table has been initialized.
-		CommDKP:SetTable(CommDKP_DB, false, InitializeCommDKPDB(CommDKP:GetTable(CommDKP_DB)))
+		CommDKP:SetTable(CommDKP_DB, false, CommDKP:InitializeCommDKPDB(CommDKP:GetTable(CommDKP_DB)))
 		core.DB = CommDKP:GetTable(CommDKP_DB); --Player specific DB
 
 		
-		if not VerifyDBSchema(CommDKP_DKPTable) then CommDKP_DKPTable =  UpgradeDBSchema(CommDKP_DKPTable, CommDKP_DKPTable, true, "CommDKP_DKPTable") end;
-		if not VerifyDBSchema(CommDKP_Loot) then CommDKP_Loot =  UpgradeDBSchema(CommDKP_Loot, CommDKP_Loot, true, "CommDKP_Loot") end;
-		if not VerifyDBSchema(CommDKP_DKPHistory) then CommDKP_DKPHistory =  UpgradeDBSchema(CommDKP_DKPHistory, CommDKP_DKPHistory, true, "CommDKP_DKPHistory") end;
-		if not VerifyDBSchema(CommDKP_MinBids) then CommDKP_MinBids =  UpgradeDBSchema(CommDKP_MinBids, CommDKP_MinBids, true, "CommDKP_MinBids") end;
-		if not VerifyDBSchema(CommDKP_MaxBids) then CommDKP_MaxBids =  UpgradeDBSchema(CommDKP_MaxBids, CommDKP_MaxBids, true, "CommDKP_MaxBids") end;
-		if not VerifyDBSchema(CommDKP_Whitelist) then CommDKP_Whitelist =  UpgradeDBSchema(CommDKP_Whitelist, CommDKP_Whitelist, false, "CommDKP_Whitelist") end;
-		if not VerifyDBSchema(CommDKP_Standby) then CommDKP_Standby =  UpgradeDBSchema(CommDKP_Standby, CommDKP_Standby, true, "CommDKP_Standby") end;
-		if not VerifyDBSchema(CommDKP_Archive) then CommDKP_Archive =  UpgradeDBSchema(CommDKP_Archive, CommDKP_Archive, true, "CommDKP_Archive") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_DKPTable) then CommDKP_DKPTable = CommDKP:UpgradeDBSchema(CommDKP_DKPTable, CommDKP_DKPTable, true, "CommDKP_DKPTable") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_Loot) then CommDKP_Loot = CommDKP:UpgradeDBSchema(CommDKP_Loot, CommDKP_Loot, true, "CommDKP_Loot") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_DKPHistory) then CommDKP_DKPHistory = CommDKP:UpgradeDBSchema(CommDKP_DKPHistory, CommDKP_DKPHistory, true, "CommDKP_DKPHistory") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_MinBids) then CommDKP_MinBids = CommDKP:UpgradeDBSchema(CommDKP_MinBids, CommDKP_MinBids, true, "CommDKP_MinBids") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_MaxBids) then CommDKP_MaxBids = CommDKP:UpgradeDBSchema(CommDKP_MaxBids, CommDKP_MaxBids, true, "CommDKP_MaxBids") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_Whitelist) then CommDKP_Whitelist = CommDKP:UpgradeDBSchema(CommDKP_Whitelist, CommDKP_Whitelist, false, "CommDKP_Whitelist") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_Standby) then CommDKP_Standby = CommDKP:UpgradeDBSchema(CommDKP_Standby, CommDKP_Standby, true, "CommDKP_Standby") end;
+		if not CommDKP:VerifyDBSchema(CommDKP_Archive) then CommDKP_Archive = CommDKP:UpgradeDBSchema(CommDKP_Archive, CommDKP_Archive, true, "CommDKP_Archive") end;
 		
 
 
@@ -610,7 +610,7 @@ function CommDKP:GetTable(dbTable, hasTeams, teamIndex)
 		local realmName = CommDKP:GetRealmName();
 		local guildName = CommDKP:GetGuildName();
 
-		dbTable = InitializeGuild(dbTable,realmName,guildName);
+		dbTable = CommDKP:InitializeGuild(dbTable,realmName,guildName);
 
 		if hasTeams then
 
@@ -641,7 +641,7 @@ function CommDKP:SetTable(dbTable, hasTeams, value, teamIndex)
 		local realmName = CommDKP:GetRealmName();
 		local guildName = CommDKP:GetGuildName();
 
-		dbTable = InitializeGuild(dbTable,realmName,guildName);
+		dbTable = CommDKP:InitializeGuild(dbTable,realmName,guildName);
 
 		if hasTeams then
 			if teamIndex == nil then
@@ -659,7 +659,7 @@ function CommDKP:SetTable(dbTable, hasTeams, value, teamIndex)
 	end
 end
 
-function VerifyDBSchema(dbTable)
+function CommDKP:VerifyDBSchema(dbTable)
 	local verified = false;
 	--Check to see if the schema node exists. If not, this is 2.1.2 database.
 	local retOK, hasInfo = pcall(tableHasKey,dbTable,"dbinfo");
@@ -673,11 +673,11 @@ function VerifyDBSchema(dbTable)
 	return verified;
 end
 
-function UpgradeDBSchema(newDbTable, oldDbTable, hasTeams, tableName)
+function CommDKP:UpgradeDBSchema(newDbTable, oldDbTable, hasTeams, tableName)
 	-- Initialize the Database for a Pre-2.2 Database
 	local retOK, hasInfo = pcall(tableHasKey,oldDbTable,"dbinfo");
 	if (not retOK) or (retOK and not hasInfo) then
-		newDbTable = InitPlayerTable(oldDbTable, hasTeams, tableName)
+		newDbTable = CommDKP:InitPlayerTable(oldDbTable, hasTeams, tableName)
 	end
 	--Set Prior Build
 	newDbTable.dbinfo.priorbuild = newDbTable.dbinfo.build;
@@ -687,7 +687,7 @@ function UpgradeDBSchema(newDbTable, oldDbTable, hasTeams, tableName)
 		if newDbTable.dbinfo.name == "CommDKP_DB" then
 
 			local defaultTable = {}
-			defaultTable = InitializeCommDKPDB(CommDKP:GetTable(defaultTable))
+			defaultTable = CommDKP:InitializeCommDKPDB(CommDKP:GetTable(defaultTable))
 			if not defaultTable.defaults.CurrentTeam then defaultTable.defaults.CurrentTeam = "0" end;
 			if not defaultTable.teams then defaultTable.teams = {} end;
 			newDbTable[core.defaultTable] = defaultTable;
@@ -698,11 +698,11 @@ function UpgradeDBSchema(newDbTable, oldDbTable, hasTeams, tableName)
 	return newDbTable;
 end
 
-function tableHasKey(table,key)
+local function tableHasKey(table,key)
 	return table[key] ~= nil;
 end
 
-function InitializeCommDKPDB(dbTable)
+function CommDKP:InitializeCommDKPDB(dbTable)
 	if not dbTable.DKPBonus or not dbTable.DKPBonus.OnTimeBonus then
 		dbTable.DKPBonus = {
 			OnTimeBonus = 15, BossKillBonus = 5, CompletionBonus = 10, NewBossKillBonus = 10, UnexcusedAbsence = -25, BidTimer = 30, DecayPercentage = 20, GiveRaidStart = false, IncStandby = false,
@@ -755,16 +755,17 @@ function InitializeCommDKPDB(dbTable)
 
 	return dbTable;
 end
-function InitPlayerTable(globalTable, hasTeams, tableName)
+
+function CommDKP:InitPlayerTable(globalTable, hasTeams, tableName)
 	local playerTable = {};
-	playerTable = InitDbSchema(playerTable, tableName);
+	playerTable = CommDKP:InitDbSchema(playerTable, tableName);
 	if IsInGuild() then
 
 		local realmName = CommDKP:GetRealmName();
 		local guildName = CommDKP:GetGuildName();
 		
 
-		playerTable = InitializeGuild(playerTable,realmName,guildName);
+		playerTable = CommDKP:InitializeGuild(playerTable,realmName,guildName);
 
 		if  not globalTable then
 			globalTable = {};
@@ -781,7 +782,7 @@ function InitPlayerTable(globalTable, hasTeams, tableName)
 	return playerTable;
 end
 
-function InitializeGuild(dataTable, realmName, guildName)
+function CommDKP:InitializeGuild(dataTable, realmName, guildName)
 	local retOK1, hasInfo1 = pcall(tableHasKey,dataTable,realmName);
 	
 	if (not retOK1) or (retOK1 and not hasInfo1) then
@@ -799,7 +800,7 @@ function InitializeGuild(dataTable, realmName, guildName)
  	return dataTable
 end
 
-function InitDbSchema(dbTable, tableName)
+function CommDKP:InitDbSchema(dbTable, tableName)
 	dbTable["dbinfo"] = {};
 	dbTable.dbinfo["build"] = 0;
 	dbTable.dbinfo["name"] = tableName;


### PR DESCRIPTION
…namespace, so you can have CommunityDKP and MonolithDKP active at the same time without interferences. This could be the foundation of a simpler migration from MonolithDKP to CommunityDKP without touching saved variables.