### PR TITLE
Loot Display Fix for #48

### DIFF
--- a/Modules/BidInterface.lua
+++ b/Modules/BidInterface.lua
@@ -358,6 +358,27 @@ end
 function CommDKP:CurrItem_Set(item, value, icon, value2)
   CurrItemForBid = item;
   CurrItemIcon = icon;
+
+  
+
+  ----------------------------------------------------------------------
+  -- Check if item is in the item list
+  -- If not then we have out of kill bid
+  -- Overwrite the list to contain only the item
+  -- Thank you to lantisnt of EssentialDKP for the assist on this.
+  -- https://github.com/lantisnt/EssentialDKP/pull/26/files#diff-c2e2b9359e4bbfc335111a2a4472c9c6
+
+  local _,tmpLink,_,_,_,_,_,_,_,tmpIcon = GetItemInfo(item)
+  local currItemInLoot = false
+
+  for _,_i in pairs(lootTable) do
+    if _i.link == tmpLink then currItemInLoot = true end
+  end
+
+  if not currItemInLoot then
+    CommDKP:LootTable_Set({{icon=tmpIcon, link=tmpLink}})
+  end
+  ----------------------------------------------------------------------
   
   UpdateBidderWindow()
 


### PR DESCRIPTION
Fixing the loot display icon when loot gets jumbled up.  Resolves #48.