### PR TITLE
Fix for Bug #64

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -335,7 +335,7 @@ function CommDKP:SendSeedData()
 			}
 		}
 	--]]
-
+	CommDKP.Sync:SendData("CommDKPQuery",{ping = true});
 	CommDKP.Sync:SendData("CommDKPSeed", latestIndexForTeam) -- requests role and spec data and sends current seeds (index of newest DKP and Loot entries)
 
 end


### PR DESCRIPTION
This appears to be connected to the work that we did to refactor the Seed information.  It's supposed to call **CommDKPQuery** when the Seed is sent, but that got left out.