### PR TITLE
Removes chat message when player passes on bid

### DIFF
--- a/Modules/comm.lua
+++ b/Modules/comm.lua
@@ -180,7 +180,8 @@ function CommDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
       elseif prefix == "CommDKPBidder" then
         if core.BidInProgress and core.IsOfficer then
           if _objReceived.Data == "pass" then
-            CommDKP:Print(sender.." has passed.")
+            -- Needs localisation at least
+            -- CommDKP:Print(sender.." has passed.")
             return
           else
             CommDKP_CHAT_MSG_WHISPER(_objReceived.Data, sender)


### PR DESCRIPTION
Just comments it out. 40 messages for each bid is needless spam.
In the future I think it would be nice to have a small window to see who has yet to pass. But for now I believe the chat messages are doing more harm than good. An alternative could be having an option to toggle these specific messages on or off.