### PR TITLE
Delay lootslot hooking 1 frame

### DIFF
--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -771,14 +771,19 @@ function CommDKP:BroadcastStopBidTimer()
 end
 
 function CommDKP_Register_ShiftClickLootWindowHook()      -- hook function into LootFrame window. All slots on ElvUI. But only first 4 in default UI.
-  local num = GetNumLootItems();
-
-  if getglobal("ElvLootSlot1") then       -- fixes hook for ElvUI loot frame
+  C_Timer.After(0.0001, function()
+    local num = GetNumLootItems();
+    local lootSlotNameTemplate = "LootButton"
+    if getglobal"ElvLootSlot1" then       -- fixes hook for ElvUI loot frame
+      lootSlotNameTemplate = "ElvLootSlot"
+    else
+      num = math.min(num, 4)
+    end
     for i = 1, num do
       local searchHook = CommDKP:Table_Search(hookedSlots, i)  -- blocks repeated hooking
 
       if not searchHook then
-        local lootSlot = getglobal("ElvLootSlot"..i)
+        local lootSlot = getglobal(lootSlotNameTemplate..i)
         if lootSlot then
           lootSlot:HookScript("OnClick", function()
                 if ( IsShiftKeyDown() and IsAltKeyDown() ) then
@@ -811,43 +816,7 @@ function CommDKP_Register_ShiftClickLootWindowHook()      -- hook function into 
         end
       end
     end
-  else
-    if num > 4 then num = 4 end
-
-    for i = 1, num do
-      local searchHook = CommDKP:Table_Search(hookedSlots, i)  -- blocks repeated hooking
-
-      if not searchHook then
-        getglobal("LootButton"..i):HookScript("OnClick", function()
-              if ( IsShiftKeyDown() and IsAltKeyDown() ) then
-                local pass, err = pcall(function()
-                  lootIcon, itemName, _, _, _ = GetLootSlotInfo(i)
-                  itemLink = GetLootSlotLink(i)
-                    CommDKP:ToggleBidWindow(itemLink, lootIcon, itemName)
-                end)
-
-            if not pass then
-              core.BiddingWindow:SetShown(false)
-              StaticPopupDialogs["SUGGEST_RELOAD"] = {
-                text = "|CFFFF0000"..L["WARNING"].."|r: "..L["MUSTRELOADUI"],
-                button1 = L["YES"],
-                button2 = L["NO"],
-                OnAccept = function()
-                  ReloadUI();
-                end,
-                timeout = 0,
-                whileDead = true,
-                hideOnEscape = true,
-                preferredIndex = 3,
-              }
-              StaticPopup_Show ("SUGGEST_RELOAD")
-            end
-              end
-        end)
-        table.insert(hookedSlots, i)
-      end
-    end
-  end
+  end)
 end
 
 function CommDKP:StartBidTimer(seconds, title, itemIcon)

--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -774,7 +774,7 @@ function CommDKP_Register_ShiftClickLootWindowHook()      -- hook function into 
   C_Timer.After(0.0001, function()
     local num = GetNumLootItems();
     local lootSlotNameTemplate = "LootButton"
-    if getglobal"ElvLootSlot1" then       -- fixes hook for ElvUI loot frame
+    if getglobal("ElvLootSlot1") then       -- fixes hook for ElvUI loot frame
       lootSlotNameTemplate = "ElvLootSlot"
     else
       num = math.min(num, 4)

--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -770,55 +770,6 @@ function CommDKP:BroadcastStopBidTimer()
   CommDKP.Sync:SendData("CommDKPCommand", "StopBidTimer")
 end
 
-function CommDKP_Register_ShiftClickLootWindowHook()      -- hook function into LootFrame window. All slots on ElvUI. But only first 4 in default UI.
-  C_Timer.After(0.0001, function()
-    local num = GetNumLootItems();
-    local lootSlotNameTemplate = "LootButton"
-    if getglobal("ElvLootSlot1") then       -- fixes hook for ElvUI loot frame
-      lootSlotNameTemplate = "ElvLootSlot"
-    else
-      num = math.min(num, 4)
-    end
-    for i = 1, num do
-      local searchHook = CommDKP:Table_Search(hookedSlots, i)  -- blocks repeated hooking
-
-      if not searchHook then
-        local lootSlot = getglobal(lootSlotNameTemplate..i)
-        if lootSlot then
-          lootSlot:HookScript("OnClick", function()
-                if ( IsShiftKeyDown() and IsAltKeyDown() ) then
-                  local pass, err = pcall(function()
-                    lootIcon, itemName, _, _, _ = GetLootSlotInfo(i)
-                    itemLink = GetLootSlotLink(i)
-                      CommDKP:ToggleBidWindow(itemLink, lootIcon, itemName)
-                  end)
-
-              if not pass then
-                CommDKP:Print(err)
-                core.BiddingWindow:SetShown(false)
-                StaticPopupDialogs["SUGGEST_RELOAD"] = {
-                  text = "|CFFFF0000"..L["WARNING"].."|r: "..L["MUSTRELOADUI"],
-                  button1 = L["YES"],
-                  button2 = L["NO"],
-                  OnAccept = function()
-                    ReloadUI();
-                  end,
-                  timeout = 0,
-                  whileDead = true,
-                  hideOnEscape = true,
-                  preferredIndex = 3,
-                }
-                StaticPopup_Show ("SUGGEST_RELOAD")
-              end
-            end
-          end)
-          table.insert(hookedSlots, i)
-        end
-      end
-    end
-  end)
-end
-
 function CommDKP:StartBidTimer(seconds, title, itemIcon)
   local duration, timer, timerText, modulo, timerMinute, expiring;
   local title = title;

--- a/init.lua
+++ b/init.lua
@@ -584,11 +584,6 @@ function CommDKP_OnEvent(self, event, arg1, ...)
 	elseif event == "LOOT_OPENED" then
 		CommDKP:CheckOfficer();
 		if core.IsOfficer then
-			if not IsInRaid() and arg1 == false then  -- only fires hook when autoloot is not active if not in a raid to prevent nil value error
-				CommDKP_Register_ShiftClickLootWindowHook()
-			elseif IsInRaid() then
-				CommDKP_Register_ShiftClickLootWindowHook()
-			end
 			local lootTable = {}
 			local lootList = {};
 


### PR DESCRIPTION
The attempt to hook lootslot frames is often happening before they exist. This causes two problems:

1. The ElvUI detection doesn't work on the first loot window.
2. Every time a loot window contains more items than any previous loot window (such as a mob dropping 2 items for the first time in a session), items past the previous cap (in this case, the second item in the loot window) do not get the hook.

Delaying 1 frame allows loot frames time to exist before being referenced.

Also removed duplicate code block. Same effect, but a smaller if statement.