### PR TITLE
Reply with addon messages

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -392,19 +392,23 @@ function CommDKP:FormatTime(time)
 	return str;
 end
 
+function CommDKP:ForcePrint(...)        --bypasses print suppression option. used as an alternative to whispers
+	local defaults = CommDKP:GetThemeColor();
+	local prefix = string.format("|cff%s%s|r|cff%s", defaults[1].hex:upper(), "CommunityDKP:", defaults[2].hex:upper());
+	local suffix = "|r";
+	
+	for i = 1, NUM_CHAT_WINDOWS do
+		local name = GetChatWindowInfo(i)
+		
+		if core.DB == nil or core.DB.defaults.ChatFrames[name] then
+			_G["ChatFrame"..i]:AddMessage(string.join(" ", prefix, ..., suffix));
+		end
+	end
+end
+
 function CommDKP:Print(...)        --print function to add "CommunityDKP:" to the beginning of print() outputs.
 	if core.DB == nil or not core.DB.defaults.SuppressNotifications then
-		local defaults = CommDKP:GetThemeColor();
-		local prefix = string.format("|cff%s%s|r|cff%s", defaults[1].hex:upper(), "CommunityDKP:", defaults[2].hex:upper());
-		local suffix = "|r";
-
-		for i = 1, NUM_CHAT_WINDOWS do
-			local name = GetChatWindowInfo(i)
-
-			if core.DB == nil or core.DB.defaults.ChatFrames[name] then
-				_G["ChatFrame"..i]:AddMessage(string.join(" ", prefix, ..., suffix));
-			end
-		end
+		return CommDKP:ForcePrint(...)
 	end
 end
 

--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -103,8 +103,8 @@ local function Roll_OnEvent(self, event, arg1, ...)
   end
 end
 
-local function BidCmd(...)
-  local _, cmd = string.split(" ", ..., 2)
+local function BidCmd(text)
+  local _, cmd = string.split(" ", text, 2)
 
   if tonumber(cmd) then
     cmd = tonumber(cmd) -- converts it to a number if it's a valid numeric string
@@ -115,21 +115,29 @@ local function BidCmd(...)
   return cmd;
 end
 
-function CommDKP_CHAT_MSG_WHISPER(text, ...)
-  local name = ...;
+local function Respond(response, name, doWhisper)
+  if doWhisper then
+    SendChatMessage(response, "WHISPER", nil, name)
+  else
+    CommDKP.Sync:SendData("CommDKPWhisper", response, name)
+  end
+end
+
+function CommDKP_OnBidderCommandReceived(text, name, doWhisperResponse)
+  doWhisperResponse = true -- temporary override for compatibility
   local cmd;
   local dkp;
   local seconds;
   local response = L["ERRORPROCESSING"];
   
   mode = core.DB.modes.mode;
-
-  if string.find(name, "-") then          -- finds and removes server name from name if exists
-    local dashPos = string.find(name, "-")
+  
+  local dashPos = string.find(name, "-")
+  if dashPos then -- finds and removes server name from name if exists
     name = strsub(name, 1, dashPos-1)
   end
 
-  if string.find(text, "!bid") == 1 and core.IsOfficer == true then
+  if string.find(text, "^[!！]bid%s+") == 1 and core.IsOfficer == true then
     if core.BidInProgress then
       cmd = BidCmd(text)
       if (mode == "Static Item Values" and cmd ~= "cancel") or (mode == "Zero Sum" and cmd ~= "cancel" and core.DB.modes.ZeroSumBidType == "Static") then
@@ -158,7 +166,7 @@ function CommDKP_CHAT_MSG_WHISPER(text, ...)
       end
       dkp = tonumber(CommDKP:GetPlayerDKP(name))
       if not dkp then    -- exits function if player is not on the DKP list
-        SendChatMessage(L["INVALIDPLAYER"], "WHISPER", nil, name)
+        Respond(L["INVALIDPLAYER"], name, doWhisperResponse)
         return
       end
 
@@ -170,7 +178,7 @@ function CommDKP_CHAT_MSG_WHISPER(text, ...)
                 if (not (mode == "Zero Sum" and core.DB.modes.ZeroSumBidType == "Static")) and Bids_Submitted[i] and Bids_Submitted[i].player == name and Bids_Submitted[i].bid < cmd then
                   table.remove(Bids_Submitted, i)
                 elseif (not (mode == "Zero Sum" and core.DB.modes.ZeroSumBidType == "Static")) and Bids_Submitted[i] and Bids_Submitted[i].player == name and Bids_Submitted[i].bid >= cmd then
-                  SendChatMessage(L["BIDEQUALORLESS"], "WHISPER", nil, name)
+                  Respond(L["BIDEQUALORLESS"], name, doWhisperResponse)
                   return
                 end
               end
@@ -247,15 +255,15 @@ function CommDKP_CHAT_MSG_WHISPER(text, ...)
           response = L["BIDDENIEDINVALID"]
         end
       end
-      SendChatMessage(response, "WHISPER", nil, name)
+      Respond(response, name, doWhisperResponse)
     else
-      SendChatMessage(L["NOBIDINPROGRESS"], "WHISPER", nil, name)
+      Respond(L["NOBIDINPROGRESS"], name, doWhisperResponse)
     end
-  elseif string.find(text, "!dkp") == 1 and core.IsOfficer == true then
+  elseif string.find(text, "^[!！]dkp") == 1 and core.IsOfficer == true then
     cmd = tostring(BidCmd(text))
 
     if cmd and cmd:gsub("%d+", "") == "" then
-      return CommDKP_CHAT_MSG_WHISPER("!bid "..cmd, name)
+      return CommDKP_OnBidderCommandReceived("!bid "..cmd, name, doWhisperResponse)
     elseif cmd and cmd:gsub("%s+", "") ~= "nil" and cmd:gsub("%s+", "") ~= "" then    -- allows command if it has content (removes empty spaces)
       cmd = cmd:gsub("%s+", "") -- removes unintended spaces from string
       CommDKP:WhisperAvailableDKP(name, cmd);
@@ -264,8 +272,7 @@ function CommDKP_CHAT_MSG_WHISPER(text, ...)
       CommDKP:WhisperAvailableDKP(name);
       return;
     end
-
-    SendChatMessage(response, "WHISPER", nil, name)
+    Respond(response, name, doWhisperResponse)
   end
 
 

--- a/Modules/comm.lua
+++ b/Modules/comm.lua
@@ -41,42 +41,43 @@ end
 -------------------------------------------------
 
 function CommDKP.Sync:OnEnable()
-  CommDKP.Sync:RegisterComm("CommDKPDelUsers", CommDKP.Sync:OnCommReceived())      -- Broadcasts deleted users (archived users not on the DKP table)
-  CommDKP.Sync:RegisterComm("CommDKPAddUsers", CommDKP.Sync:OnCommReceived())   -- Broadcasts newly added users (or recovers)
-  CommDKP.Sync:RegisterComm("CommDKPMerge", CommDKP.Sync:OnCommReceived())      -- Broadcasts 2 weeks of data from officers (for merging)
+  CommDKP.Sync:RegisterComm("CommDKPDelUsers",   CommDKP.Sync:OnCommReceived()) -- Broadcasts deleted users (archived users not on the DKP table)
+  CommDKP.Sync:RegisterComm("CommDKPAddUsers",   CommDKP.Sync:OnCommReceived()) -- Broadcasts newly added users (or recovers)
+  CommDKP.Sync:RegisterComm("CommDKPMerge",      CommDKP.Sync:OnCommReceived()) -- Broadcasts 2 weeks of data from officers (for merging)
   -- Normal broadcast Prefixs
-  CommDKP.Sync:RegisterComm("CommDKPDecay", CommDKP.Sync:OnCommReceived())        -- Broadcasts a weekly decay adjustment
-  CommDKP.Sync:RegisterComm("CommDKPBCastMsg", CommDKP.Sync:OnCommReceived())      -- broadcasts a message that is printed as is
-  CommDKP.Sync:RegisterComm("CommDKPCommand", CommDKP.Sync:OnCommReceived())      -- broadcasts a command (ex. timers, bid timers, stop all timers etc.)
-  CommDKP.Sync:RegisterComm("CommDKPLootDist", CommDKP.Sync:OnCommReceived())      -- broadcasts individual loot award to loot table
-  CommDKP.Sync:RegisterComm("CommDKPDelLoot", CommDKP.Sync:OnCommReceived())      -- broadcasts deleted loot award entries
-  CommDKP.Sync:RegisterComm("CommDKPDelSync", CommDKP.Sync:OnCommReceived())      -- broadcasts deleated DKP history entries
-  CommDKP.Sync:RegisterComm("CommDKPDKPDist", CommDKP.Sync:OnCommReceived())      -- broadcasts individual DKP award to DKP history table
-  CommDKP.Sync:RegisterComm("CommDKPMinBid", CommDKP.Sync:OnCommReceived())      -- broadcasts minimum dkp values (set in Options tab or custom values in bid window)
-  CommDKP.Sync:RegisterComm("CommDKPMaxBid", CommDKP.Sync:OnCommReceived())      -- broadcasts maximum dkp values (set in Options tab or custom values in bid window)
-  CommDKP.Sync:RegisterComm("CDKPWhitelist", CommDKP.Sync:OnCommReceived())      -- broadcasts whitelist
-  CommDKP.Sync:RegisterComm("CommDKPDKPModes", CommDKP.Sync:OnCommReceived())      -- broadcasts DKP Mode settings
-  CommDKP.Sync:RegisterComm("CommDKPStand", CommDKP.Sync:OnCommReceived())        -- broadcasts standby list
-  CommDKP.Sync:RegisterComm("CommDKPRaidTime", CommDKP.Sync:OnCommReceived())      -- broadcasts Raid Timer Commands
-  CommDKP.Sync:RegisterComm("CommDKPZSumBank", CommDKP.Sync:OnCommReceived())    -- broadcasts ZeroSum Bank
-  CommDKP.Sync:RegisterComm("CommDKPQuery", CommDKP.Sync:OnCommReceived())        -- Querys guild for spec/role data
-  CommDKP.Sync:RegisterComm("CommDKPSeed", CommDKP.Sync:OnCommReceived())
-  CommDKP.Sync:RegisterComm("CommDKPBuild", CommDKP.Sync:OnCommReceived())        -- broadcasts Addon build number to inform others an update is available.
-  CommDKP.Sync:RegisterComm("CommDKPTalents", CommDKP.Sync:OnCommReceived())      -- broadcasts current spec
-  CommDKP.Sync:RegisterComm("CommDKPRoles", CommDKP.Sync:OnCommReceived())        -- broadcasts current role info
-  CommDKP.Sync:RegisterComm("CommDKPBossLoot", CommDKP.Sync:OnCommReceived())      -- broadcast current loot table
-  CommDKP.Sync:RegisterComm("CommDKPBidShare", CommDKP.Sync:OnCommReceived())      -- broadcast accepted bids
-  CommDKP.Sync:RegisterComm("CommDKPBidder", CommDKP.Sync:OnCommReceived())      -- Submit bids
-  CommDKP.Sync:RegisterComm("CommDKPAllTabs", CommDKP.Sync:OnCommReceived())      -- Full table broadcast
-  CommDKP.Sync:RegisterComm("CommDKPSetPrice", CommDKP.Sync:OnCommReceived())      -- Set Single Item Price
-  CommDKP.Sync:RegisterComm("CommDKPCurTeam", CommDKP.Sync:OnCommReceived())      -- Sets Current Raid Team
-  CommDKP.Sync:RegisterComm("CommDKPTeams", CommDKP.Sync:OnCommReceived())
-  CommDKP.Sync:RegisterComm("CommDKPPreBroad", CommDKP.Sync:OnCommReceived()) -- send info that full broadcast is starting
-  --CommDKP.Sync:RegisterComm("CommDKPEditLoot", CommDKP.Sync:OnCommReceived())    -- not in use
-  --CommDKP.Sync:RegisterComm("CommDKPDataSync", CommDKP.Sync:OnCommReceived())    -- not in use
-  --CommDKP.Sync:RegisterComm("CommDKPDKPLogSync", CommDKP.Sync:OnCommReceived())  -- not in use
-  --CommDKP.Sync:RegisterComm("CommDKPLogSync", CommDKP.Sync:OnCommReceived())    -- not in use
-  CommDKP.Sync:RegisterComm("CDKProfileSend", CommDKP.Sync:OnCommReceived()) -- Broadcast Player Profile for Update or Create
+  CommDKP.Sync:RegisterComm("CommDKPDecay",      CommDKP.Sync:OnCommReceived()) -- Broadcasts a weekly decay adjustment
+  CommDKP.Sync:RegisterComm("CommDKPBCastMsg",   CommDKP.Sync:OnCommReceived()) -- broadcasts a message that is printed as is
+  CommDKP.Sync:RegisterComm("CommDKPCommand",    CommDKP.Sync:OnCommReceived()) -- broadcasts a command (ex. timers, bid timers, stop all timers etc.)
+  CommDKP.Sync:RegisterComm("CommDKPLootDist",   CommDKP.Sync:OnCommReceived()) -- broadcasts individual loot award to loot table
+  CommDKP.Sync:RegisterComm("CommDKPDelLoot",    CommDKP.Sync:OnCommReceived()) -- broadcasts deleted loot award entries
+  CommDKP.Sync:RegisterComm("CommDKPDelSync",    CommDKP.Sync:OnCommReceived()) -- broadcasts deleated DKP history entries
+  CommDKP.Sync:RegisterComm("CommDKPDKPDist",    CommDKP.Sync:OnCommReceived()) -- broadcasts individual DKP award to DKP history table
+  CommDKP.Sync:RegisterComm("CommDKPMinBid",     CommDKP.Sync:OnCommReceived()) -- broadcasts minimum dkp values (set in Options tab or custom values in bid window)
+  CommDKP.Sync:RegisterComm("CommDKPMaxBid",     CommDKP.Sync:OnCommReceived()) -- broadcasts maximum dkp values (set in Options tab or custom values in bid window)
+  CommDKP.Sync:RegisterComm("CDKPWhitelist",     CommDKP.Sync:OnCommReceived()) -- broadcasts whitelist
+  CommDKP.Sync:RegisterComm("CommDKPDKPModes",   CommDKP.Sync:OnCommReceived()) -- broadcasts DKP Mode settings
+  CommDKP.Sync:RegisterComm("CommDKPStand",      CommDKP.Sync:OnCommReceived()) -- broadcasts standby list
+  CommDKP.Sync:RegisterComm("CommDKPRaidTime",   CommDKP.Sync:OnCommReceived()) -- broadcasts Raid Timer Commands
+  CommDKP.Sync:RegisterComm("CommDKPZSumBank",   CommDKP.Sync:OnCommReceived()) -- broadcasts ZeroSum Bank
+  CommDKP.Sync:RegisterComm("CommDKPQuery",      CommDKP.Sync:OnCommReceived()) -- Querys guild for spec/role data
+  CommDKP.Sync:RegisterComm("CommDKPSeed",       CommDKP.Sync:OnCommReceived())
+  CommDKP.Sync:RegisterComm("CommDKPBuild",      CommDKP.Sync:OnCommReceived()) -- broadcasts Addon build number to inform others an update is available.
+  CommDKP.Sync:RegisterComm("CommDKPTalents",    CommDKP.Sync:OnCommReceived()) -- broadcasts current spec
+  CommDKP.Sync:RegisterComm("CommDKPRoles",      CommDKP.Sync:OnCommReceived()) -- broadcasts current role info
+  CommDKP.Sync:RegisterComm("CommDKPBossLoot",   CommDKP.Sync:OnCommReceived()) -- broadcast current loot table
+  CommDKP.Sync:RegisterComm("CommDKPBidShare",   CommDKP.Sync:OnCommReceived()) -- broadcast accepted bids
+  CommDKP.Sync:RegisterComm("CommDKPBidder",     CommDKP.Sync:OnCommReceived()) -- Submit bid
+  CommDKP.Sync:RegisterComm("CommDKPWhisper",    CommDKP.Sync:OnCommReceived()) -- Used for responses sometimes to cut down on whispers
+  CommDKP.Sync:RegisterComm("CommDKPAllTabs",    CommDKP.Sync:OnCommReceived()) -- Full table broadcast
+  CommDKP.Sync:RegisterComm("CommDKPSetPrice",   CommDKP.Sync:OnCommReceived()) -- Set Single Item Price
+  CommDKP.Sync:RegisterComm("CommDKPCurTeam",    CommDKP.Sync:OnCommReceived()) -- Sets Current Raid Team
+  CommDKP.Sync:RegisterComm("CommDKPTeams",      CommDKP.Sync:OnCommReceived())
+  CommDKP.Sync:RegisterComm("CommDKPPreBroad",   CommDKP.Sync:OnCommReceived()) -- send info that full broadcast is starting
+  -- CommDKP.Sync:RegisterComm("CommDKPEditLoot",   CommDKP.Sync:OnCommReceived()) -- not in use
+  -- CommDKP.Sync:RegisterComm("CommDKPDataSync",   CommDKP.Sync:OnCommReceived()) -- not in use
+  -- CommDKP.Sync:RegisterComm("CommDKPDKPLogSync", CommDKP.Sync:OnCommReceived()) -- not in use
+  -- CommDKP.Sync:RegisterComm("CommDKPLogSync",    CommDKP.Sync:OnCommReceived()) -- not in use
+  CommDKP.Sync:RegisterComm("CDKProfileSend",    CommDKP.Sync:OnCommReceived()) -- Broadcast Player Profile for Update or Create
 end
 
 function CommDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
@@ -183,12 +184,14 @@ function CommDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
               -- CommDKP:Print(sender.." has passed.")  --TODO: Let's do something different here at some point.
             return
           else
-            CommDKP_CHAT_MSG_WHISPER(_objReceived.Data, sender)
+            CommDKP_OnBidderCommandReceived(_objReceived.Data, sender, false)
             return
           end
         else
           return
         end
+      elseif prefix == "CommDKPWhisper" then
+        CommDKP:ForcePrint(_objReceived.Data)
       elseif prefix == "CommDKPTeams" then
         CommDKP:GetTable(CommDKP_DB, false)["teams"] = _objReceived.Teams
         return;

--- a/init.lua
+++ b/init.lua
@@ -445,9 +445,10 @@ function CommDKP_OnEvent(self, event, arg1, ...)
 		if core.IsOfficer then
 
 			arg1 = strlower(arg1)
-			if (core.BidInProgress or string.find(arg1, "!dkp") == 1 or string.find(arg1, "！dkp") == 1) then
-				CommDKP_CHAT_MSG_WHISPER(arg1, ...)
-			elseif string.find(arg1, "!standby") == 1 and core.StandbyActive then
+			if (core.BidInProgress or string.find(arg1, "^[!！]dkp")) then
+        local name = ...
+				CommDKP_OnBidderCommandReceived(arg1, name, true)
+			elseif string.find(arg1, "^!standby") == 1 and core.StandbyActive then
 				CommDKP_Standby_Handler(arg1, ...)
 			end
 		end
@@ -463,8 +464,9 @@ function CommDKP_OnEvent(self, event, arg1, ...)
 	elseif event == "CHAT_MSG_RAID" or event == "CHAT_MSG_RAID_LEADER" then
 		CommDKP:CheckOfficer()
 		arg1 = strlower(arg1)
-		if (core.BidInProgress or string.find(arg1, "!dkp") == 1 or string.find(arg1, "!standby") == 1 or string.find(arg1, "！dkp") == 1) and core.IsOfficer == true then
-			CommDKP_CHAT_MSG_WHISPER(arg1, ...)
+		if (core.BidInProgress or string.find(arg1, "^[!！]dkp") or string.find(arg1, "^[!！]standby")) and core.IsOfficer == true then
+      local name = ...
+			CommDKP_OnBidderCommandReceived(arg1, name, true)
 		end
 	elseif event == "UPDATE_INSTANCE_INFO" then
 		local num = GetNumSavedInstances()
@@ -519,8 +521,9 @@ function CommDKP_OnEvent(self, event, arg1, ...)
 		CommDKP:CheckOfficer()
 		if core.IsOfficer then
 			arg1 = strlower(arg1)
-			if (core.BidInProgress or string.find(arg1, "!dkp") == 1 or string.find(arg1, "！dkp") == 1) and core.DB.modes.channels.guild then
-				CommDKP_CHAT_MSG_WHISPER(arg1, ...)
+			if (core.BidInProgress or string.find(arg1, "^[!！]dkp")) and core.DB.modes.channels.guild then
+        local name = ...
+				CommDKP_OnBidderCommandReceived(arg1, name, true)
 			elseif string.find(arg1, "!standby") == 1 and core.StandbyActive then
 				CommDKP_Standby_Handler(arg1, ...)
 			end


### PR DESCRIPTION
I plan to do more with Bidding.lua, but this change ought to get through asap so players have time to update so they can receive the addon messages.

The point of this is to reduce the number of whispers. Even when bid whispers are suppressed, a toast window opens in chat for every player I auto-reply to with a whisper.