### PR TITLE
Feature/decay numbers

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -804,9 +804,10 @@ end
 -- if the result is 1 level deeper, it would be CommDKP:GetTable(CommDKP_DKPTable, true)[search[1][1]][search[1][2]][search[1][3]].  CommDKP:GetTable(CommDKP_DKPTable, true)[search[2][1]][search[2][2]][search[2][3]] would locate the second return, if there is one.
 -- use to search for players in SavedVariables. Only two possible returns is the table or false.
 -------------------------------------
-function CommDKP:Table_Search(tar, val, field)
+function CommDKP:Table_Search(tar, val, field, limit)
 	local value = string.upper(tostring(val));
 	local location = {}
+	local tableLimit = limit or -1;
 	for k,v in pairs(tar) do
 		if(type(v) == "table") then
 			local temp1 = k
@@ -821,9 +822,15 @@ function CommDKP:Table_Search(tar, val, field)
 									if field then
 										if k == field then
 											tinsert(location, {temp1, temp2, temp3, k} )
+											if tableLimit ~= -1 and #location >= tableLimit then
+												return location;
+											end;
 										end
 									else
 										tinsert(location, {temp1, temp2, temp3, k} )
+										if tableLimit ~= -1 and #location >= tableLimit then
+											return location;
+										end;
 									end
 								end;
 							end
@@ -832,9 +839,15 @@ function CommDKP:Table_Search(tar, val, field)
 							if field then
 								if k == field then
 									tinsert(location, {temp1, temp2, k} )
+									if tableLimit ~= -1 and #location >= tableLimit then
+										return location;
+									end;
 								end
 							else
 								tinsert(location, {temp1, temp2, k} )
+								if tableLimit ~= -1 and #location >= tableLimit then
+									return location;
+								end;
 							end
 						end;
 					end
@@ -843,9 +856,15 @@ function CommDKP:Table_Search(tar, val, field)
 					if field then
 						if k == field then
 							tinsert(location, {temp1, k} )
+							if tableLimit ~= -1 and #location >= tableLimit then
+								return location;
+							end;
 						end
 					else
 						tinsert(location, {temp1, k} )
+						if tableLimit ~= -1 and #location >= tableLimit then
+							return location;
+						end;
 					end
 				end;
 			end
@@ -854,9 +873,15 @@ function CommDKP:Table_Search(tar, val, field)
 			if field then
 				if k == field then
 					tinsert(location, k)
+					if tableLimit ~= -1 and #location >= tableLimit then
+						return location;
+					end;
 				end
 			else
 				tinsert(location, k)
+				if tableLimit ~= -1 and #location >= tableLimit then
+					return location;
+				end;
 			end
 		end;
 	end
@@ -867,9 +892,10 @@ function CommDKP:Table_Search(tar, val, field)
 	end
 end
 
-function CommDKP:TableStrFind(tar, val, field)              -- same function as above, but searches values that contain the searched string rather than exact string matches
+function CommDKP:TableStrFind(tar, val, field, limit)              -- same function as above, but searches values that contain the searched string rather than exact string matches
 	local value = string.upper(tostring(val));        -- ex. CommDKP:TableStrFind(CommDKP:GetTable(CommDKP_DKPHistory, true), "Vapok") will return the path to any table element that contains "Vapok"
 	local location = {}
+	local tableLimit = limit or -1 -- so some functions dont operate on huge tables when they need like last 20 records...
 	for k,v in pairs(tar) do
 		if(type(v) == "table") then
 			local temp1 = k
@@ -884,9 +910,15 @@ function CommDKP:TableStrFind(tar, val, field)              -- same function as 
 									if field then
 										if k == field then
 											tinsert(location, {temp1, temp2, temp3, k} )
+											if tableLimit ~= -1 and #location >= tableLimit then
+												return location;
+											end;
 										end
 									else
 										tinsert(location, {temp1, temp2, temp3, k} )
+										if tableLimit ~= -1 and #location >= tableLimit then
+											return location;
+										end;
 									end
 								end;
 							end
@@ -895,9 +927,15 @@ function CommDKP:TableStrFind(tar, val, field)              -- same function as 
 							if field then
 								if k == field then
 									tinsert(location, {temp1, temp2, k} )
+									if tableLimit ~= -1 and #location >= tableLimit then
+										return location;
+									end;
 								end
 							else
 								tinsert(location, {temp1, temp2, k} )
+								if tableLimit ~= -1 and #location >= tableLimit then
+									return location;
+								end;
 							end
 						end;
 					end
@@ -906,9 +944,15 @@ function CommDKP:TableStrFind(tar, val, field)              -- same function as 
 					if field then
 						if k == field then
 							tinsert(location, {temp1, k} )
+							if tableLimit ~= -1 and #location >= tableLimit then
+								return location;
+							end;
 						end
 					else
 						tinsert(location, {temp1, k} )
+						if tableLimit ~= -1 and #location >= tableLimit then
+							return location;
+						end;
 					end
 				end;
 			end
@@ -917,9 +961,15 @@ function CommDKP:TableStrFind(tar, val, field)              -- same function as 
 			if field then
 				if k == field then
 					tinsert(location, k)
+					if tableLimit ~= -1 and #location >= tableLimit then
+						return location;
+					end;
 				end
 			else
 				tinsert(location, k)
+				if tableLimit ~= -1 and #location >= tableLimit then
+					return location;
+				end;
 			end
 		end;
 	end

--- a/Modules/DKPHistory.lua
+++ b/Modules/DKPHistory.lua
@@ -446,7 +446,7 @@ function CommDKP:DKPHistory_Update(reset)
 					CommDKP.ConfigTab6.history[i].d:SetText("|cffff0000"..decay[#playerIndex].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
 				elseif strfind(reason, L["WEEKLYDECAY"]) or strfind(reason, "Migration Correction") then
 					local decay = {strsplit(",", dkp)}
-					CommDKP.ConfigTab6.history[i].d:SetText("|cffff0000"..decay[#decay].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");..decay[#decay].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
+					CommDKP.ConfigTab6.history[i].d:SetText("|cffff0000"..decay[#decay].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r"..decay[#decay].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
 				else
 					CommDKP.ConfigTab6.history[i].d:SetText("|cffff0000"..dkp.." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
 				end

--- a/Modules/DKPHistory.lua
+++ b/Modules/DKPHistory.lua
@@ -438,9 +438,15 @@ function CommDKP:DKPHistory_Update(reset)
 			if not strfind(dkp, "-") then
 				CommDKP.ConfigTab6.history[i].d:SetText("|cff00ff00"..dkp.." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
 			else
-				if strfind(reason, L["WEEKLYDECAY"]) or strfind(reason, "Migration Correction") then
+				if filter and filter ~= L["DELETEDENTRY"] and strfind(reason, L["WEEKLYDECAY"]) then
 					local decay = {strsplit(",", dkp)}
-					CommDKP.ConfigTab6.history[i].d:SetText("|cffff0000"..decay[#decay].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
+					-- get substring till player name and split to get correct player index for decay list
+					local playerIndex = {strsplit(",", string.sub(players, 1, strfind(players, filter..",")))};
+					-- Print decay value using playerIndex instead of percentage
+					CommDKP.ConfigTab6.history[i].d:SetText("|cffff0000"..decay[#playerIndex].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
+				elseif strfind(reason, L["WEEKLYDECAY"]) or strfind(reason, "Migration Correction") then
+					local decay = {strsplit(",", dkp)}
+					CommDKP.ConfigTab6.history[i].d:SetText("|cffff0000"..decay[#decay].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");..decay[#decay].." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
 				else
 					CommDKP.ConfigTab6.history[i].d:SetText("|cffff0000"..dkp.." "..L["DKP"].."|r - |cff616ccf"..reason.."|r |cff555555("..timeofday..")|r by |c"..c.hex..curOfficer.."|r");
 				end

--- a/TableFunctions.lua
+++ b/TableFunctions.lua
@@ -108,9 +108,9 @@ local function DisplayUserHistory(self, player)
 	local PlayerTable = {}
 	local c, PlayerSearch, PlayerSearch2, LifetimeSearch, RowCount, curDate;
 
-	PlayerSearch = CommDKP:TableStrFind(CommDKP:GetTable(CommDKP_DKPHistory, true), player, "players")
-	PlayerSearch2 = CommDKP:Table_Search(CommDKP:GetTable(CommDKP_Loot, true), player, "player")
-	LifetimeSearch = CommDKP:Table_Search(CommDKP:GetTable(CommDKP_DKPTable, true), player, "player")
+	PlayerSearch = CommDKP:TableStrFind(CommDKP:GetTable(CommDKP_DKPHistory, true), player, "players", 20)
+	PlayerSearch2 = CommDKP:Table_Search(CommDKP:GetTable(CommDKP_Loot, true), player, "player", 20)
+	LifetimeSearch = CommDKP:Table_Search(CommDKP:GetTable(CommDKP_DKPTable, true), player, "player", 20)
 
 	c = CommDKP:GetCColors(CommDKP:GetTable(CommDKP_DKPTable, true)[LifetimeSearch[1][1]].class)
 
@@ -120,7 +120,14 @@ local function DisplayUserHistory(self, player)
 	if PlayerSearch then
 		for i=1, #PlayerSearch do
 			if not CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].deletes and not CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].deletedby and not CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].hidden then
-				tinsert(PlayerTable, {reason = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].reason, date = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].date, dkp = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].dkp, players = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].players}})
+				tinsert(
+					PlayerTable, {
+						reason = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].reason, 
+						date = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].date, 
+						dkp = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].dkp, 
+						players = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].players
+					}
+				)
 			end
 		end
 	end
@@ -128,7 +135,13 @@ local function DisplayUserHistory(self, player)
 	if PlayerSearch2 then
 		for i=1, #PlayerSearch2 do
 			if not CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].deletes and not CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].deletedby and not CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].hidden then
-				tinsert(PlayerTable, {loot = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].loot, date = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].date, zone = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].zone, boss = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].boss, cost = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].cost})
+				tinsert(PlayerTable, {
+					loot = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].loot, 
+					date = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].date, 
+					zone = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].zone, 
+					boss = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].boss, 
+					cost = CommDKP:GetTable(CommDKP_Loot, true)[PlayerSearch2[i][1]].cost
+				})
 			end
 		end
 	end

--- a/TableFunctions.lua
+++ b/TableFunctions.lua
@@ -120,7 +120,7 @@ local function DisplayUserHistory(self, player)
 	if PlayerSearch then
 		for i=1, #PlayerSearch do
 			if not CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].deletes and not CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].deletedby and not CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].hidden then
-				tinsert(PlayerTable, {reason = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].reason, date = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].date, dkp = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].dkp})
+				tinsert(PlayerTable, {reason = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].reason, date = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].date, dkp = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].dkp, players = CommDKP:GetTable(CommDKP_DKPHistory, true)[PlayerSearch[i][1]].players}})
 			end
 		end
 	end
@@ -152,7 +152,9 @@ local function DisplayUserHistory(self, player)
 			if PlayerTable[i].dkp then
 				if strfind(PlayerTable[i].dkp, "%%") then
 					local decay = {strsplit(",", PlayerTable[i].dkp)}
-					GameTooltip:AddDoubleLine("  "..PlayerTable[i].reason, "|cffff0000"..decay[#decay].." DKP|r", 1.0, 0, 0);
+					-- get substring till player name and split to get correct player index for decay list
+					local playerIndex = {strsplit(",", string.sub(PlayerTable[i].players, 1, (strfind(PlayerTable[i].players, player..","))))};
+					GameTooltip:AddDoubleLine("  "..PlayerTable[i].reason, "|cffff0000"..decay[#playerIndex].." DKP|r", 1.0, 0, 0);
 				elseif tonumber(PlayerTable[i].dkp) < 0 then
 					GameTooltip:AddDoubleLine("  "..PlayerTable[i].reason, "|cffff0000"..CommDKP_round(PlayerTable[i].dkp, core.DB.modes.rounding).." DKP|r", 1.0, 0, 0);
 				else


### PR DESCRIPTION
We had a small feature request to be able to see actual Decay values instead of percentage. Sounded like a nice place for me to start looking at code and making a small update.
Only shows in tooltip when hovering the table and on filtered DKP History. Unfiltered still shows percentage.